### PR TITLE
small changes to services to work with spacy 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,78 @@ Curl command:
 curl -s localhost:8000/dep -d '{"text":"Pastafarians are smarter than people with Coca Cola bottles.", "model":"en"}'
 ```
 
+```json
+{
+  "arcs": [
+    {
+      "dir": "left",
+      "end": 1,
+      "label": "nsubj",
+      "start": 0
+    },
+    {
+      "dir": "right",
+      "end": 2,
+      "label": "acomp",
+      "start": 1
+    },
+    {
+      "dir": "right",
+      "end": 3,
+      "label": "prep",
+      "start": 2
+    },
+    {
+      "dir": "right",
+      "end": 4,
+      "label": "pobj",
+      "start": 3
+    },
+    {
+      "dir": "right",
+      "end": 5,
+      "label": "prep",
+      "start": 4
+    },
+    {
+      "dir": "right",
+      "end": 6,
+      "label": "pobj",
+      "start": 5
+    }
+  ],
+  "words": [
+    {
+      "tag": "NNPS",
+      "text": "Pastafarians"
+    },
+    {
+      "tag": "VBP",
+      "text": "are"
+    },
+    {
+      "tag": "JJR",
+      "text": "smarter"
+    },
+    {
+      "tag": "IN",
+      "text": "than"
+    },
+    {
+      "tag": "NNS",
+      "text": "people"
+    },
+    {
+      "tag": "IN",
+      "text": "with"
+    },
+    {
+      "tag": "NNS",
+      "text": "Coca Cola bottles."
+    }
+  ]
+}
+```
 
 
 ### `POST` `/ent/`
@@ -106,11 +178,29 @@ Example response:
 | `start` | integer | character offset the entity starts **on** |
 | `type` | string | entity type |
 
----
+
 
 ```
 curl -s localhost:8000/ent -d '{"text":"Pastafarians are smarter than people with Coca Cola bottles.", "model":"en"}'
 ```
+
+```json
+[
+  {
+    "end": 12,
+    "start": 0,
+    "type": "NORP"
+  },
+  {
+    "end": 51,
+    "start": 42,
+    "type": "ORG"
+  }
+]
+```
+
+
+---
 
 ### `GET` `/models`
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Example response:
 
 ---
 
+Curl command:
+
+```
+curl -s localhost:8000/dep -d '{"text":"Pastafarians are smarter than people with Coca Cola bottles.", "model":"en"}'
+```
+
+
+
 ### `POST` `/ent/`
 
 Example request:
@@ -99,6 +107,10 @@ Example response:
 | `type` | string | entity type |
 
 ---
+
+```
+curl -s localhost:8000/ent -d '{"text":"Pastafarians are smarter than people with Coca Cola bottles.", "model":"en"}'
+```
 
 ### `GET` `/models`
 

--- a/displacy/app.py
+++ b/displacy/app.py
@@ -1,4 +1,4 @@
-from displacy.server import APP, get_model
+from displacy_service.server import APP, get_model
 
 # Pre-load English and German models
 get_model('en')

--- a/displacy/app.py
+++ b/displacy/app.py
@@ -1,8 +1,8 @@
 from displacy_service.server import APP, get_model
 
-# Pre-load English and German models
+# Pre-load English model only, to save memory
 get_model('en')
-get_model('de')
+# get_model('de')
 
 
 if __name__ == '__main__':

--- a/displacy/displacy_service/server.py
+++ b/displacy/displacy_service/server.py
@@ -62,20 +62,27 @@ def get_pos_types(model):
 
 
 class ModelsResource(object):
-    """List the available models."""
+    """List the available models.
+
+    test with: curl -s localhost:8000/models
+    """
     def on_get(self, req, resp):
         try:
             output = list(MODELS)
-            resp.body = json.dumps(output.to_json(), sort_keys=True, indent=2)
-            resp.content_type = b'text/string'
-            resp.append_header(b'Access-Control-Allow-Origin', b"*")
+            resp.body = json.dumps(output, sort_keys=True, indent=2)
+            resp.content_type = 'text/string'
+            resp.append_header('Access-Control-Allow-Origin', "*")
             resp.status = falcon.HTTP_200
         except Exception:
             resp.status = falcon.HTTP_500
 
 
 class SchemaResource(object):
-    """Describe the annotation scheme of a model."""
+    """Describe the annotation scheme of a model.
+
+    This does not appear to work with later spacy
+    versions.
+    """
     def on_get(self, req, resp, model_name):
         try:
             model = get_model(model_name)
@@ -85,16 +92,22 @@ class SchemaResource(object):
                 'pos_types': get_pos_types(model)
             }
 
-            resp.body = json.dumps(output.to_json(), sort_keys=True, indent=2)
-            resp.content_type = b'text/string'
-            resp.append_header(b'Access-Control-Allow-Origin', b"*")
+            resp.body = json.dumps(output, sort_keys=True, indent=2)
+            resp.content_type = 'text/string'
+            resp.append_header('Access-Control-Allow-Origin', "*")
             resp.status = falcon.HTTP_200
-        except Exception:
+        except Exception as e:
+            raise falcon.HTTPBadRequest(
+                'Schema construction failed',
+                '{}'.format(e))
             resp.status = falcon.HTTP_500
 
 
 class DepResource(object):
-    """Parse text and return displacy's expected JSON output."""
+    """Parse text and return displacy's expected JSON output.
+
+    test with: curl -s localhost:8000/dep -d '{"text":"Pastafarians are smarter than people with Coca Cola bottles."}'
+    """
     def on_post(self, req, resp):
         req_body = req.stream.read()
         json_data = json.loads(req_body.decode('utf8'))
@@ -107,8 +120,8 @@ class DepResource(object):
             model = get_model(model_name)
             parse = Parse(model, text, collapse_punctuation, collapse_phrases)
             resp.body = json.dumps(parse.to_json(), sort_keys=True, indent=2)
-            resp.content_type = b'text/string'
-            resp.append_header(b'Access-Control-Allow-Origin', b"*")
+            resp.content_type = 'text/string'
+            resp.append_header('Access-Control-Allow-Origin', "*")
             resp.status = falcon.HTTP_200
         except Exception:
             resp.status = falcon.HTTP_500
@@ -124,9 +137,10 @@ class EntResource(object):
         try:
             model = get_model(model_name)
             entities = Entities(model, text)
-            resp.body = json.dumps(entities.to_json(), sort_keys=True, indent=2)
-            resp.content_type = b'text/string'
-            resp.append_header(b'Access-Control-Allow-Origin', b"*")
+            resp.body = json.dumps(entities.to_json(), sort_keys=True,
+                                   indent=2)
+            resp.content_type = 'text/string'
+            resp.append_header('Access-Control-Allow-Origin', "*")
             resp.status = falcon.HTTP_200
         except Exception:
             resp.status = falcon.HTTP_500

--- a/displacy/displacy_service/server.py
+++ b/displacy/displacy_service/server.py
@@ -123,7 +123,10 @@ class DepResource(object):
             resp.content_type = 'text/string'
             resp.append_header('Access-Control-Allow-Origin', "*")
             resp.status = falcon.HTTP_200
-        except Exception:
+        except Exception as e:
+            raise falcon.HTTPBadRequest(
+                'Dependency parsing failed',
+                '{}'.format(e))
             resp.status = falcon.HTTP_500
 
 


### PR DESCRIPTION
There were a couple of small errors in the implementation of the /models and {model_name}/schema paths, a mistake in file naming for app.py (had displacy.server, needed displacy_service.server). Also a systematic problem with falcon and header strings, which work for me if provided as '...' but not if provided as b'....' . 

The schema detection implementation still doesn't work, but returns a better error