### PR TITLE
small fix: update the POST /ent ex. req with a mapped model key

### DIFF
--- a/displacy/README.md
+++ b/displacy/README.md
@@ -90,7 +90,7 @@ name.
 ```json
 {
     "text": "When Sebastian Thrun started working on self-driving cars at Google in 2007, few people outside of the company took him seriously.",
-    "model": "en"
+    "model": "en_core_web_sm"
 }
 ```
 


### PR DESCRIPTION
loved the example(s)

just a small doc change.

just ran cloned and ran this locally, but saw the `POST /ent` example wasn't referencing a valid model.
